### PR TITLE
Fix type def of decodeFromImage() param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ class QrcodeDecoder {
    *  refer to jsqr options: https://github.com/cozmo/jsQR
    */
   async decodeFromImage(
-    img: HTMLImageElement,
+    img: HTMLImageElement | string,
     options: { crossOrigin?: string } = {},
   ) {
     let imgDom: HTMLImageElement | null = null;
@@ -237,12 +237,8 @@ class QrcodeDecoder {
       ...this.defaultOption,
       ...options,
     };
-    if (+img.nodeType > 0) {
-      if (!img.src) {
-        throw new Error('The ImageElement must contain a src');
-      }
-      imgDom = img;
-    } else if (typeof img === 'string') {
+
+    if (typeof img === 'string') {
       imgDom = document.createElement('img');
       if (options.crossOrigin) {
         imgDom.crossOrigin = options.crossOrigin;
@@ -253,6 +249,11 @@ class QrcodeDecoder {
           imgDom!.onload = () => resolve(true);
         });
       await proms();
+    } else if (+img.nodeType > 0) {
+      if (!img.src) {
+        throw new Error('The ImageElement must contain a src');
+      }
+      imgDom = img;
     }
 
     let code = null;


### PR DESCRIPTION
The decodeFromImage() function accepts a string type as an argument. And this works as expected. However, when use TypeScript, actually setting the string type causes a type definition error.

Example:

```ts
const qrCodeBase64Str = 'data:image/png;base64...'
const qrCodeDecoder = new QrCodeDecoder()
qrCodeDecoder.decodeFromImage(qrCodeBase64Str).then((result) => console.log(result))
// => Error: "Argument of type 'string' is not assignable to parameter of type 'HTMLImageElement'."
```

This PR prevents the type definition error from occurring.